### PR TITLE
ref: components that were exporting a function now export an arrow fu…

### DIFF
--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -25,9 +25,9 @@ export const googleLogin = async ({
   return response.data;
 };
 
-export function logout() {
+export const logout = () => {
   const { setUser, setToken } = useUserStore.getState();
 
   setUser(null);
   setToken(null);
-}
+};

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -15,7 +15,7 @@ function matches(breakpoint: Breakpoint) {
   return query.matches;
 }
 
-export function useBreakpoint(breakpoint: Breakpoint) {
+export const useBreakpoint = (breakpoint: Breakpoint) => {
   const [match, setMatch] = useState(matches(breakpoint));
 
   useLayoutEffect(() => {
@@ -33,4 +33,4 @@ export function useBreakpoint(breakpoint: Breakpoint) {
   });
 
   return match;
-}
+};

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -4,7 +4,7 @@ import { useOutlet } from "react-router-dom";
 import { NavBar } from "./NavBar";
 import { Sidebar } from "./Sidebar";
 
-export function Layout() {
+export const Layout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const outlet = useOutlet();
 
@@ -21,4 +21,4 @@ export function Layout() {
       </div>
     </div>
   );
-}
+};

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ export interface SidebarProps {
   onClose: () => void;
 }
 
-export function Sidebar({ show, onClose }: SidebarProps) {
+export const Sidebar = ({ show, onClose }: SidebarProps) => {
   const location = useLocation();
   const current = location.pathname;
 
@@ -143,4 +143,4 @@ export function Sidebar({ show, onClose }: SidebarProps) {
       </div>
     </>
   );
-}
+};

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,7 +1,7 @@
 import { MODAL_ROUTES, useNavigateModal } from "~/router";
 import { Button } from "~/ui";
 
-export function Home() {
+export const Home = () => {
   const navigateModal = useNavigateModal();
   return (
     <div className="prose p-10 lg:prose-xl">


### PR DESCRIPTION
# ⚡ Change components from functions to arrow functions in React boilerplate - [86dr3pc0b](https://app.clickup.com/t/86dr3pc0b) ⚡

## 💻 What type of change is this?

- [ ] 💎 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Styling
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI

## ⭐ Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
Example:
-->

Components went from this:
```
export function MyComponent () {
  // ...
}
```

To this:
```
export const MyComponent = () => {
  // ...
}
```

## ✅ Checklist

- [x] This PR can be merged (it is not a draft, work in progress, or blocked on another PR)
- [ ] I have tested this change locally in multiple screen sizes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
