### PR TITLE
feat: adjust auth store to standard

### DIFF
--- a/src/api/interceptors/authHeader.ts
+++ b/src/api/interceptors/authHeader.ts
@@ -1,9 +1,9 @@
 import type { InternalAxiosRequestConfig } from "axios";
 
-import { useAuthStore } from "~/stores";
+import { authStore } from "~/stores";
 
 export const authHeaderInterceptor = (config: InternalAxiosRequestConfig) => {
-  const { token } = useAuthStore.getState();
+  const { token } = authStore.getState();
 
   config.headers.Authorization = token ? `Bearer ${token}` : undefined;
 

--- a/src/api/interceptors/refreshToken.ts
+++ b/src/api/interceptors/refreshToken.ts
@@ -1,6 +1,6 @@
 import mem from "mem";
 
-import { setToken } from "~/stores";
+import { authStore } from "~/stores";
 import type { ServiceResponse } from "../api.types";
 import { api } from "../axios";
 
@@ -22,13 +22,13 @@ const refreshToken = async () => {
     );
     const { data: userToken } = response.data;
     if (!userToken.refresh_token) {
-      setToken(null);
+      authStore.setToken(null);
     } else {
       refreshWasSuccessful = true;
-      setToken(userToken.refresh_token);
+      authStore.setToken(userToken.refresh_token);
     }
   } catch (error) {
-    setToken(null);
+    authStore.setToken(null);
   }
   return refreshWasSuccessful;
 };

--- a/src/api/interceptors/refreshToken.ts
+++ b/src/api/interceptors/refreshToken.ts
@@ -1,10 +1,8 @@
 import mem from "mem";
 
-import { useAuthStore } from "~/stores";
+import { setToken } from "~/stores";
 import type { ServiceResponse } from "../api.types";
 import { api } from "../axios";
-
-const { setToken } = useAuthStore.getState();
 
 export interface UserToken {
   refresh_token: string;

--- a/src/domains/guest/api/login.ts
+++ b/src/domains/guest/api/login.ts
@@ -1,6 +1,6 @@
 import { api } from "~/api";
 import type { ServiceResponse } from "~/api";
-import { useAuthStore } from "~/stores";
+import { setToken } from "~/stores";
 
 export type UserToken = {
   accessToken: string;
@@ -27,7 +27,5 @@ export const googleLogin = async ({
 };
 
 export const logout = () => {
-  const { setToken } = useAuthStore.getState();
-
   setToken(null);
 };

--- a/src/domains/guest/api/login.ts
+++ b/src/domains/guest/api/login.ts
@@ -1,6 +1,6 @@
 import { api } from "~/api";
 import type { ServiceResponse } from "~/api";
-import { setToken } from "~/stores";
+import { authStore } from "~/stores";
 
 export type UserToken = {
   accessToken: string;
@@ -27,5 +27,5 @@ export const googleLogin = async ({
 };
 
 export const logout = () => {
-  setToken(null);
+  authStore.setToken(null);
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import "~/config/providers/scripts/sentry";
+import "~/providers/sentry/sentry";
 
 import React, { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import "~/providers/sentry/sentry";
+import "~/config/providers/scripts/sentry";
 
 import React, { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/src/router/components/RouterWrapper/RouterWrapper.tsx
+++ b/src/router/components/RouterWrapper/RouterWrapper.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import { MainLayout } from "~/router";
-import { useAuthStore } from "~/stores";
+import { authStore } from "~/stores";
 
 type Props = PropsWithChildren & {
   guest?: boolean;
 };
 
 export const RouterWrapper = ({ guest = false, children }: Props) => {
-  const isAuthenticated = useAuthStore((state) => state.token);
+  const isAuthenticated = authStore.getToken();
 
   if (!guest && !isAuthenticated) {
     return <Navigate to='/404' />;

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,2 +1,2 @@
-export * from "./useAuthStore";
+export * as authStore from "./useAuthStore";
 export * as exampleStore from "./useExampleStore";

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -12,7 +12,7 @@ export type AuthStoreState = {
   token: string | null;
 };
 
-export const useAuthStore = create<AuthStoreState>()(
+const useAuthStore = create<AuthStoreState>()(
   persist(
     (_) => ({
       token: null,
@@ -22,6 +22,10 @@ export const useAuthStore = create<AuthStoreState>()(
     },
   ),
 );
+
+export const getState = () => useAuthStore.getState();
+
+export const getToken = () => useAuthStore((state) => state.token);
 
 export const setToken = (token: string | null) =>
   useAuthStore.setState(() => ({ token }));

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,14 +1,8 @@
 /**
- * This file represents an alternative pattern when using Zustand's `persist` middleware.
- * In this case, we include actions within the store itself, as `persist` handles state persistence
- * across sessions. Unlike our standard approach where actions are externalized, here we centralize
- * state and actions for ease of persistence management.
- *
  * The `persist` middleware automatically saves the `token` to localStorage under the key "authStore".
  * We only store the `token` here to comply with HIPAA regulations, ensuring that no sensitive user information
  * beyond authentication tokens is persisted.
  *
- * This pattern is specifically used when persistence is required, overriding our standard practice of separating state and actions.
  */
 
 import { create } from "zustand";
@@ -16,19 +10,18 @@ import { persist } from "zustand/middleware";
 
 export type AuthStoreState = {
   token: string | null;
-  setToken(token: string | null): void;
 };
 
 export const useAuthStore = create<AuthStoreState>()(
   persist(
-    (set) => ({
+    (_) => ({
       token: null,
-      setToken: (token: string | null) => {
-        set(() => ({ token }));
-      },
     }),
     {
       name: "authStore",
     },
   ),
 );
+
+export const setToken = (token: string | null) =>
+  useAuthStore.setState(() => ({ token }));

--- a/src/stores/useExampleStore.ts
+++ b/src/stores/useExampleStore.ts
@@ -14,17 +14,21 @@ export type ExampleStoreState = {
   thirdValue: number | null;
 };
 
-export const useStore = create<ExampleStoreState>()(() => ({
+const useStore = create<ExampleStoreState>(() => ({
   firstValue: null,
   secondValue: null,
   thirdValue: null,
 }));
 
-export const setFirstValue = () =>
-  useStore.setState((state) => ({ firstValue: state.firstValue }));
+export const getFirstValue = () => useStore((state) => state.firstValue);
+export const getSecondValue = () => useStore((state) => state.secondValue);
+export const getThirdValue = () => useStore((state) => state.thirdValue);
 
-export const setSecondValue = () =>
-  useStore.setState((state) => ({ secondValue: state.secondValue }));
+export const setFirstValue = (firstValue: ExampleStoreState["firstValue"]) =>
+  useStore.setState(() => ({ firstValue }));
 
-export const setThirdValue = () =>
-  useStore.setState((state) => ({ thirdValue: state.thirdValue }));
+export const setSecondValue = (secondValue: ExampleStoreState["secondValue"]) =>
+  useStore.setState(() => ({ secondValue }));
+
+export const setThirdValue = (thirdValue: ExampleStoreState["thirdValue"]) =>
+  useStore.setState(() => ({ thirdValue }));

--- a/src/stores/useExampleStore.ts
+++ b/src/stores/useExampleStore.ts
@@ -1,11 +1,7 @@
 /**
- * This file adheres to our standard for Zustand stores without using `persist`.
+ * This file adheres to our standard for Zustand stores.
  * The state and actions are externalized, promoting modularity and separation of concerns,
  * as outlined in Zustand's best practices: https://zustand.docs.pmnd.rs/guides/practice-with-no-store-actions.
- *
- * We use a namespace in the barrel file (e.g., export * as authStore from "./useAuthStore")
- * to gather everything in one place, achieving both objectives: keeping concerns separate while avoiding
- * multiple setters with similar names, as often seen in component states or sections.
  *
  * This structure simplifies state management and ensures consistency across the project.
  */


### PR DESCRIPTION
# ⚡ {0} - [{1}](https://app.clickup.com/t/{2}) ⚡

## 💻 What type of change is this?

- [{3}] 💎 Feature
- [{4}] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Styling
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI

## ⭐ Description

- Makes all our stores comply with our standard, persisted stores shouldn't be written different as they should behave the same.
- Wasn't able to test it since we don't have a login implemented. But chat GPT says this:

```
Yes, the token will still be persisted to localStorage even though setToken is defined outside the store definition. Here’s why:

Zustand’s setState function: The setToken function simply calls useAuthStore.setState, which is a built-in function provided by Zustand to update the store's state. This method directly interacts with the store.

Persist Middleware: When you use the persist middleware, Zustand wraps the store with additional logic to automatically synchronize any changes made to the store state with localStorage. In this case, since persist is configured to store the state under the key "authStore", any changes to the token (whether done via setToken or any other update function) will be saved to localStorage.

So, even though setToken is defined outside the store, as long as it calls useAuthStore.setState, it updates the state in a way that triggers the persist logic to store the updated token in localStorage.
```

## 📷 Screenshots

n/a

## 💬 Comments

n/a

## ✅ Checklist

### Requirements

- [ ] This change includes database migrations
- [ ] This PR requires changes in the `.env` file
- [ ] This PR requires to rebuild a table or run a cron manually
- [x] This PR can be merged (it is not a draft, work in progress, or blocked on another PR)

### To review

- [ ] I have tested this change locally in multiple screen sizes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If my task include an endpoint, I add the endpoint to Hopscotch/Postman Project
- [ ] Any dependent changes have been merged and published in downstream modules
